### PR TITLE
Allow to index parsed content in the file field

### DIFF
--- a/src/test/java/org/elasticsearch/plugin/mapper/attachments/test/MultipleAttachmentWithParsedIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/plugin/mapper/attachments/test/MultipleAttachmentWithParsedIntegrationTests.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Test case for issue https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/18
  */
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
-public class MultipleAttachmentIntegrationTests extends ElasticsearchIntegrationTest {
+public class MultipleAttachmentWithParsedIntegrationTests extends ElasticsearchIntegrationTest {
     private boolean ignore_errors = true;
 
     @Override
@@ -55,6 +55,7 @@ public class MultipleAttachmentIntegrationTests extends ElasticsearchIntegration
         return settingsBuilder()
                 .put("index.numberOfReplicas", 0)
                 .put("index.mapping.attachment.ignore_errors", ignore_errors)
+                .put("index.analysis.analyzer.plain.tokenizer", "whitespace")
             .build();
     }
 
@@ -67,7 +68,7 @@ public class MultipleAttachmentIntegrationTests extends ElasticsearchIntegration
         logger.info("creating index [test]");
         createIndex("test");
 
-        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multipledocs/test-mapping.json");
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multipledocs/test-mapping-file.json");
         byte[] html = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/xcontent/htmlWithValidDateMeta.html");
         byte[] pdf = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/xcontent/encrypted.pdf");
 
@@ -83,7 +84,10 @@ public class MultipleAttachmentIntegrationTests extends ElasticsearchIntegration
         countResponse = client().prepareCount("test").setQuery(queryString("World").defaultField("hello")).execute().get();
         assertThat(countResponse.getCount(), equalTo(1l));
 
-        countResponse = client().prepareCount("test").setQuery(queryString("file1.file:World").defaultField("hello")).execute().get();
+        countResponse = client().prepareCount("test").setQuery(queryString("file1.file:World")).execute().get();
+        assertThat(countResponse.getCount(), equalTo(1l));
+
+        countResponse = client().prepareCount("test").setQuery(queryString("file1.file:world")).execute().get();
         assertThat(countResponse.getCount(), equalTo(0l));
     }
 
@@ -97,7 +101,7 @@ public class MultipleAttachmentIntegrationTests extends ElasticsearchIntegration
         logger.info("creating index [test]");
         createIndex("test");
 
-        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multipledocs/test-mapping.json");
+        String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multipledocs/test-mapping-file.json");
         byte[] html = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/xcontent/htmlWithValidDateMeta.html");
         byte[] pdf = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/xcontent/encrypted.pdf");
 

--- a/src/test/resources/org/elasticsearch/index/mapper/multipledocs/test-mapping-file.json
+++ b/src/test/resources/org/elasticsearch/index/mapper/multipledocs/test-mapping-file.json
@@ -1,0 +1,18 @@
+{
+    "person":{
+        "properties":{
+            "file1":{
+                "type":"attachment",
+                "fields": {
+                    "file": {
+                        "type": "string",
+                        "analyzer": "plain"
+                    }
+                }
+            },
+            "file2":{
+                "type":"attachment"
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the README it is noted that the tika result is indexed in the `file`
field. As I had a use case where I need to analyze the tika result in
different ways I was trying to do exactly that but it did not work as
advertised. Although at first I was able to get around it I now need to
be able to do that. The result is this pull request. Part of me hopes,
that I just missed something, another part hopes that the work was not
redundant.

When reading the code I noticed that the tika result is indexed directly
in the base field name (`AttachmentMapper.contentMapper`) and not in the
`file` field. So I went on and added this feature. Obviously it can be
expensive to index the tika result multiple times (we have PDFs of
several MB) so I wanted this to be optional.

My first attempt was to add another index setting but this would have
meant that all fields of the `attachment` type would be indexed like
this. The version now is basically checking whether there exists a
`fields.file` mapping and only then indexes the content again in
it. This is not really explicit so I am basically hoping for some
feedback on how to make it explicit or even if it is ok the way it is
implemented.

For testing purposes I have copied the
`MultipleAttachmentIntegrationTest` to a
`MultipleAttachmentWithFileIntegrationTest` that is using the
`test-mapping-file.json` mapping. The index contains a `plain` analyzer
only with a `whitespace` tokenizer and the mapping for the `file`
sub-field uses that to analyze the content:

```javascript
{
    "my_attachment": {
        "type": "attachment",
        "fields": {
            "file": {"type": "string", "analyzer": "plain"}
        }
    }
}
```

This pull request is for the 1.3 branch which is the most important one
for me regarding this pull request for now. I am very happy to provide
another one for master if you like the idea and way of implementation of
this one.

Unfortunately I will have to pull a Leeroy Jenkins on this one and
probably bring this to a live environment this week...