### PR TITLE
Tika might fails depending on the Locale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>
         <tests.client.ratio></tests.client.ratio>
+        <tests.locale>random</tests.locale>
         <es.logger.level>INFO</es.logger.level>
     </properties>
 
@@ -217,6 +218,7 @@
                                 <tests.showSuccess>${tests.showSuccess}</tests.showSuccess>
                                 <tests.integration>${tests.integration}</tests.integration>
                                 <tests.cluster_seed>${tests.cluster_seed}</tests.cluster_seed>
+                                <tests.locale>${tests.locale}</tests.locale>
                                 <tests.client.ratio>${tests.client.ratio}</tests.client.ratio>
                                 <es.node.local>${env.ES_TEST_LOCAL}</es.node.local>
                                 <es.node.mode>${es.node.mode}</es.node.mode>

--- a/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.mapper.attachment;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.util.Constants;
+import org.apache.tika.Tika;
 import org.apache.tika.language.LanguageIdentifier;
 import org.apache.tika.metadata.Metadata;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
@@ -35,6 +37,7 @@ import org.elasticsearch.index.mapper.core.AbstractFieldMapper;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.index.mapper.MapperBuilders.*;
@@ -63,7 +66,7 @@ import static org.elasticsearch.plugin.mapper.attachments.tika.TikaInstance.tika
  */
 public class AttachmentMapper extends AbstractFieldMapper<Object> {
 
-    private static ESLogger logger = ESLoggerFactory.getLogger(AttachmentMapper.class.getName());
+    private static ESLogger logger = ESLoggerFactory.getLogger("mapper.attachment");
 
     public static final String CONTENT_TYPE = "attachment";
 
@@ -427,8 +430,20 @@ public class AttachmentMapper extends AbstractFieldMapper<Object> {
 
         String parsedContent;
         try {
+            Tika tika = tika();
+            if (tika == null) {
+                if (!ignoreErrors) {
+                    throw new MapperParsingException("Tika can not be initialized with the current Locale [" +
+                            Locale.getDefault().getLanguage() + "] on the current JVM [" +
+                            Constants.JAVA_VERSION + "]");
+                } else {
+                    logger.warn("Tika can not be initialized with the current Locale [{}] on the current JVM [{}]",
+                            Locale.getDefault().getLanguage(), Constants.JAVA_VERSION);
+                    return;
+                }
+            }
             // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
-            parsedContent = tika().parseToString(new BytesStreamInput(content, false), metadata, indexedChars);
+            parsedContent = tika.parseToString(new BytesStreamInput(content, false), metadata, indexedChars);
         } catch (Throwable e) {
             // It could happen that Tika adds a System property `sun.font.fontmanager` which should not happen
             // TODO Remove when this will be fixed in Tika. See https://issues.apache.org/jira/browse/TIKA-1548

--- a/src/main/java/org/elasticsearch/plugin/mapper/attachments/tika/LocaleChecker.java
+++ b/src/main/java/org/elasticsearch/plugin/mapper/attachments/tika/LocaleChecker.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugin.mapper.attachments.tika;
+
+import org.apache.lucene.util.Constants;
+
+import java.util.Locale;
+import java.util.StringTokenizer;
+
+import static java.lang.Integer.parseInt;
+
+public class LocaleChecker {
+    public static int JVM_MAJOR_VERSION = 0;
+    public static int JVM_MINOR_VERSION = 0;
+    public static int JVM_PATCH_MAJOR_VERSION = 0;
+    public static int JVM_PATCH_MINOR_VERSION = 0;
+
+    static {
+        StringTokenizer st = new StringTokenizer(Constants.JAVA_VERSION, ".");
+        JVM_MAJOR_VERSION = parseInt(st.nextToken());
+        if(st.hasMoreTokens()) {
+            JVM_MINOR_VERSION = parseInt(st.nextToken());
+        }
+        if(st.hasMoreTokens()) {
+            StringTokenizer stPatch = new StringTokenizer(st.nextToken(), "_");
+            JVM_PATCH_MAJOR_VERSION = parseInt(stPatch.nextToken());
+            JVM_PATCH_MINOR_VERSION = parseInt(stPatch.nextToken());
+        }
+    }
+
+    /**
+     * We can have issues with some JVMs and Locale
+     * See https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/105
+     */
+    public static boolean isLocaleCompatible() {
+        String language = Locale.getDefault().getLanguage();
+        boolean acceptedLocale = true;
+
+        if (
+            // We can have issues with JDK7 Patch < 80
+                (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION == 7 && JVM_PATCH_MAJOR_VERSION == 0 && JVM_PATCH_MINOR_VERSION < 80) ||
+                        // We can have issues with JDK8 Patch < 40
+                        (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION == 8 && JVM_PATCH_MAJOR_VERSION == 0 && JVM_PATCH_MINOR_VERSION < 40)
+                ) {
+            if (language.equalsIgnoreCase("tr") || language.equalsIgnoreCase("az")) {
+                acceptedLocale = false;
+            }
+        }
+
+        return acceptedLocale;
+    }
+}

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/MapperTestUtils.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/MapperTestUtils.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper.attachment.test;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Injector;
@@ -45,6 +46,11 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCacheListener;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Locale;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeTrue;
+import static org.elasticsearch.plugin.mapper.attachments.tika.LocaleChecker.isLocaleCompatible;
 
 public class MapperTestUtils {
 
@@ -94,4 +100,14 @@ public class MapperTestUtils {
                 .build();
         return new DocumentMapperParser(new Index("test"), forcedSettings, MapperTestUtils.newAnalysisService(forcedSettings), null, null, null, null);
     }
+
+    /**
+     * We can have issues with some JVMs and Locale
+     * See https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/105
+     */
+    public static void assumeCorrectLocale() {
+        assumeTrue("Current Locale language " + Locale.getDefault().getLanguage() +" could cause an error with Java " +
+                Constants.JAVA_VERSION, isLocaleCompatible());
+    }
+
 }

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/integration/AttachmentIntegrationTestCase.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/integration/AttachmentIntegrationTestCase.java
@@ -17,29 +17,31 @@
  * under the License.
  */
 
-package org.elasticsearch.plugin.mapper.attachments.tika;
+package org.elasticsearch.index.mapper.attachment.test.integration;
 
-
-import org.apache.tika.Tika;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.hamcrest.Matcher;
+import org.junit.BeforeClass;
 
 import static org.elasticsearch.plugin.mapper.attachments.tika.LocaleChecker.isLocaleCompatible;
+import static org.hamcrest.Matchers.not;
 
-/**
- *
- */
-public class TikaInstance {
+@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
+public class AttachmentIntegrationTestCase extends ElasticsearchIntegrationTest {
 
-    private static final Tika tika;
+    protected static boolean expectError;
 
-    static {
-        if (isLocaleCompatible()) {
-           tika = new Tika();
-        } else {
-            tika = null;
-        }
+    @BeforeClass
+    public static void expectErrorWithCurrentLocale() {
+        expectError = !isLocaleCompatible();
     }
 
-    public static Tika tika() {
-        return tika;
+    protected static  <T> boolean assertThatWithError(T actual, Matcher<T> expected) {
+        if (expectError) {
+            assertThat(actual, not(expected));
+        } else {
+            assertThat(actual, expected);
+        }
+        return !expectError;
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/integration/EncryptedAttachmentIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/integration/EncryptedAttachmentIntegrationTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.plugins.PluginsService;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import static org.elasticsearch.client.Requests.putMappingRequest;
@@ -38,8 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * Test case for issue https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/18
  */
-@ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE)
-public class EncryptedAttachmentIntegrationTests extends ElasticsearchIntegrationTest {
+public class EncryptedAttachmentIntegrationTests extends AttachmentIntegrationTestCase {
     private boolean ignore_errors = true;
 
     @Override
@@ -78,7 +76,7 @@ public class EncryptedAttachmentIntegrationTests extends ElasticsearchIntegratio
 
 
         CountResponse countResponse = client().prepareCount("test").setQuery(queryString("World").defaultField("file1")).execute().get();
-        assertThat(countResponse.getCount(), equalTo(1l));
+        assertThatWithError(countResponse.getCount(), equalTo(1l));
 
         countResponse = client().prepareCount("test").setQuery(queryString("World").defaultField("hello")).execute().get();
         assertThat(countResponse.getCount(), equalTo(1l));

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/AttachmentUnitTestCase.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/AttachmentUnitTestCase.java
@@ -17,29 +17,20 @@
  * under the License.
  */
 
-package org.elasticsearch.plugin.mapper.attachments.tika;
+package org.elasticsearch.index.mapper.attachment.test.unit;
 
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.BeforeClass;
 
-import org.apache.tika.Tika;
+import static org.elasticsearch.index.mapper.attachment.test.MapperTestUtils.assumeCorrectLocale;
 
-import static org.elasticsearch.plugin.mapper.attachments.tika.LocaleChecker.isLocaleCompatible;
-
-/**
- *
- */
-public class TikaInstance {
-
-    private static final Tika tika;
-
-    static {
-        if (isLocaleCompatible()) {
-           tika = new Tika();
-        } else {
-            tika = null;
-        }
-    }
-
-    public static Tika tika() {
-        return tika;
+public class AttachmentUnitTestCase extends ElasticsearchTestCase {
+    /**
+     * We can have issues with some JVMs and Locale
+     * See https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/105
+     */
+    @BeforeClass
+    public static void checkLocale() {
+        assumeCorrectLocale();
     }
 }

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/DateAttachmentMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/DateAttachmentMapperTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.attachment.AttachmentMapper;
 import org.elasticsearch.index.mapper.attachment.test.MapperTestUtils;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ import static org.hamcrest.Matchers.instanceOf;
 /**
  *
  */
-public class DateAttachmentMapperTests extends ElasticsearchTestCase {
+public class DateAttachmentMapperTests extends AttachmentUnitTestCase {
 
     private DocumentMapperParser mapperParser;
 

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/EncryptedDocMapperTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/EncryptedDocMapperTest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.attachment.AttachmentMapper;
 import org.elasticsearch.index.mapper.attachment.test.MapperTestUtils;
-import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,7 +41,7 @@ import static org.hamcrest.Matchers.*;
  * Note that we have converted /org/elasticsearch/index/mapper/xcontent/testContentLength.txt
  * to a /org/elasticsearch/index/mapper/xcontent/encrypted.pdf with password `12345678`.
  */
-public class EncryptedDocMapperTest extends ElasticsearchTestCase {
+public class EncryptedDocMapperTest extends AttachmentUnitTestCase {
 
     @Test
     public void testMultipleDocsEncryptedLast() throws IOException {

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/LanguageDetectionAttachmentMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/LanguageDetectionAttachmentMapperTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.attachment.AttachmentMapper;
 import org.elasticsearch.index.mapper.attachment.test.MapperTestUtils;
 import org.elasticsearch.index.mapper.core.StringFieldMapper;
-import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,7 +41,7 @@ import static org.hamcrest.Matchers.instanceOf;
 /**
  *
  */
-public class LanguageDetectionAttachmentMapperTests extends ElasticsearchTestCase {
+public class LanguageDetectionAttachmentMapperTests extends AttachmentUnitTestCase {
 
     private DocumentMapper docMapper;
 

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/MetadataMapperTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/MetadataMapperTest.java
@@ -28,7 +28,6 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.attachment.AttachmentMapper;
 import org.elasticsearch.index.mapper.attachment.test.MapperTestUtils;
-import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -41,7 +40,7 @@ import static org.hamcrest.Matchers.*;
 /**
  * Test for https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/38
  */
-public class MetadataMapperTest extends ElasticsearchTestCase {
+public class MetadataMapperTest extends AttachmentUnitTestCase {
 
     protected void checkMeta(String filename, Settings settings, Long expectedDate, Long expectedLength) throws IOException {
         DocumentMapperParser mapperParser = MapperTestUtils.newMapperParser(settings);

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/MultifieldAttachmentMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/MultifieldAttachmentMapperTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.*;
 /**
  *
  */
-public class MultifieldAttachmentMapperTests extends ElasticsearchTestCase {
+public class MultifieldAttachmentMapperTests extends AttachmentUnitTestCase {
 
     private DocumentMapperParser mapperParser;
     private ThreadPool threadPool;

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/SimpleAttachmentMapperTests.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/SimpleAttachmentMapperTests.java
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  *
  */
-public class SimpleAttachmentMapperTests extends ElasticsearchTestCase {
+public class SimpleAttachmentMapperTests extends AttachmentUnitTestCase {
 
     private DocumentMapperParser mapperParser;
 

--- a/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/VariousDocTest.java
+++ b/src/test/java/org/elasticsearch/index/mapper/attachment/test/unit/VariousDocTest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper.attachment.test.unit;
 
+import org.apache.tika.Tika;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -26,7 +27,6 @@ import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.attachment.AttachmentMapper;
 import org.elasticsearch.index.mapper.attachment.test.MapperTestUtils;
-import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.not;
 /**
  * Test for different documents
  */
-public class VariousDocTest extends ElasticsearchTestCase {
+public class VariousDocTest extends AttachmentUnitTestCase {
 
     /**
      * Test for https://github.com/elasticsearch/elasticsearch-mapper-attachments/issues/104
@@ -92,8 +92,11 @@ public class VariousDocTest extends ElasticsearchTestCase {
     }
 
     protected void testTika(String filename, boolean errorExpected) {
+        Tika tika = tika();
+        assumeTrue("Tika has been disabled. Ignoring test...", tika != null);
+
         try (InputStream is = VariousDocTest.class.getResourceAsStream("/org/elasticsearch/index/mapper/attachment/test/sample-files/" + filename)) {
-            String parsedContent = tika().parseToString(is);
+            String parsedContent = tika.parseToString(is);
             assertThat(parsedContent, not(isEmptyOrNullString()));
             logger.debug("extracted content: {}", parsedContent);
         } catch (Throwable e) {


### PR DESCRIPTION
Tika might fail with some Locale under some JVMs. We now check that won't happen before creating a Tika instance.
That will generate a `WARN` in logs like:

```
Tika can not be initialized with the current Locale [tr] on the current JVM [1.7.0_60]
```

To check that Tika is not initialized, you can run the test suite with:

```sh
mvn test -Dtests.output=always -Dtests.locale=tr
```

Closes #105.